### PR TITLE
Move validation to its own function, use pytest fixture (duplicated c…

### DIFF
--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -151,18 +151,7 @@ class XtriggerManager(object):
             ValueError: if any string template in the function context
                 arguments are not present in the expected template values.
         """
-        fname = fctx.func_name
-        try:
-            func = get_func(fname, fdir)
-        except ImportError:
-            raise ImportError(
-                f"ERROR: xtrigger module '{fname}' not found")
-        except AttributeError:
-            raise AttributeError(
-                f"ERROR: '{fname}' not found in xtrigger module '{fname}'")
-        if not callable(func):
-            raise ValueError(
-                f"ERROR: '{fname}' not callable in xtrigger module '{fname}'")
+        self.validate_xtrigger(fctx.func_name, fdir)
         self.functx_map[label] = fctx
         # Check any string templates in the function arg values (note this
         # won't catch bad task-specific values - which are added dynamically).
@@ -175,6 +164,30 @@ class XtriggerManager(object):
             except TypeError:
                 # Not a string arg.
                 pass
+
+    def validate_xtrigger(self, fname: str, fdir: str):
+        """Validate an Xtrigger function.
+
+        Args:
+            fname (str): function name
+            fdir(str): function directory
+        Raises:
+            ImportError: if the function module was not found
+            AttributeError: if the function was not found in the xtrigger
+                module
+            ValueError: if the function is not callable
+        """
+        try:
+            func = get_func(fname, fdir)
+        except ImportError:
+            raise ImportError(
+                f"ERROR: xtrigger module '{fname}' not found")
+        except AttributeError:
+            raise AttributeError(
+                f"ERROR: '{fname}' not found in xtrigger module '{fname}'")
+        if not callable(func):
+            raise ValueError(
+                f"ERROR: '{fname}' not callable in xtrigger module '{fname}'")
 
     def load_xtrigger_for_restart(self, row_idx: int, row: Tuple[str, str]):
         """Load satisfied xtrigger results from suite DB.


### PR DESCRIPTION
Hi @hjoliver 

Take a look at this PR code example. Used [fixtures](https://docs.pytest.org/en/latest/fixture.html) in Pytest, which are methods that match against parameter names (i.e. `def pizza` goes into `def fn1(pizza)` automagically), to remove the need to disable validation everywhere.

Also added some dummy code to get a sequence to use in the `xtrig_labels`... but I feel like I didn't really know what I was doing... there are two tests failing, which I don't know how to fix... in one the we were supposed to have 2 active xtriggers but they were not (even though `satisfy_xtriggers` was called).

![](https://i.imgur.com/xsjw8ES.png)

The other one was related to the satisfied xtriggers after running `.housekeeping` in the `XtriggerManager`. I don't recall much of how that worked... but maybe you can use either some of this PR or from the Riot chat's code as base for fix the test in your branch 👍 

Bruno