### PR TITLE
reftest: always log triggering events at info level for reftests

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1270,6 +1270,9 @@ class Scheduler:
             self.task_job_mgr.task_remote_mgr.rsync_includes = (
                 self.config.get_validated_rsync_includes())
 
+            meth = LOG.debug
+            if self.options.reftest or self.options.genref:
+                meth = LOG.info
             for itask in self.task_job_mgr.submit_task_jobs(
                 self.workflow,
                 self.pre_submit_tasks,
@@ -1278,7 +1281,7 @@ class Scheduler:
                 self.config.run_mode('simulation')
             ):
                 # (Not using f"{itask}"_here to avoid breaking func tests)
-                LOG.debug(
+                meth(
                     f"{itask.identity} -triggered off "
                     f"{itask.state.get_resolved_dependencies()}"
                 )

--- a/tests/flakyfunctional/cylc-poll/16-execution-time-limit/flow.cylc
+++ b/tests/flakyfunctional/cylc-poll/16-execution-time-limit/flow.cylc
@@ -8,7 +8,7 @@
 [scheduling]
     [[graph]]
         R1 = """
-            foo:fail? => ! foo
+            foo:fail => bar
         """
 [runtime]
     [[foo]]
@@ -23,3 +23,4 @@
         """
         [[[job]]]
             execution time limit = PT5S
+    [[bar]]

--- a/tests/flakyfunctional/cylc-poll/16-execution-time-limit/reference.log
+++ b/tests/flakyfunctional/cylc-poll/16-execution-time-limit/reference.log
@@ -1,3 +1,4 @@
 Initial point: 1
 Final point: 1
 1/foo -triggered off []
+1/bar -triggered off ['1/foo']

--- a/tests/functional/broadcast/00-simple.t
+++ b/tests/functional/broadcast/00-simple.t
@@ -23,7 +23,7 @@ install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
 workflow_run_ok "${TEST_NAME_BASE}-run" \
-    cylc play --no-detach --debug --reference-test "${WORKFLOW_NAME}"
+    cylc play --no-detach --reference-test "${WORKFLOW_NAME}"
 sort "${WORKFLOW_RUN_DIR}/share/broadcast.log" >'broadcast.log.sorted'
 cmp_ok 'broadcast.ref' 'broadcast.log.sorted'
 

--- a/tests/functional/broadcast/00-simple/flow.cylc
+++ b/tests/functional/broadcast/00-simple/flow.cylc
@@ -92,9 +92,7 @@
            sed -i '/BASH_XTRACEFD/d' ${PREPLOG}.err
 
            diff -u "${CYLC_WORKFLOW_RUN_DIR}/expected-prep.out" ${PREPLOG}.out
-           # Let's not compare stderr here; it can be contaminated by debug
-           # output from parsec (repeated config items).
-           # diff -u "${CYLC_WORKFLOW_RUN_DIR}/expected-prep.err" ${PREPLOG}.err
+           diff -u "${CYLC_WORKFLOW_RUN_DIR}/expected-prep.err" ${PREPLOG}.err
         """
     [[ENS]]
     [[ENS1]]

--- a/tests/functional/cylc-play/05-start-task.t
+++ b/tests/functional/cylc-play/05-start-task.t
@@ -25,6 +25,6 @@ install_workflow "${TEST_NAME_BASE}"
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
 
 workflow_run_ok "${TEST_NAME_BASE}-run" \
-    cylc play --no-detach --debug --reference-test -t 3/bar -t 3/war "${WORKFLOW_NAME}"
+    cylc play --no-detach --reference-test -t 3/bar -t 3/war "${WORKFLOW_NAME}"
 
 purge

--- a/tests/functional/jinja2/05-commandline.t
+++ b/tests/functional/jinja2/05-commandline.t
@@ -30,7 +30,7 @@ run_ok "${TEST_NAME}" cylc validate \
     --set-file="${TEST_DIR}/${WORKFLOW_NAME}/vars.txt" "${WORKFLOW_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-run"
-workflow_run_ok "${TEST_NAME}" cylc play --no-detach --debug --reference-test \
+workflow_run_ok "${TEST_NAME}" cylc play --no-detach --reference-test \
     --set-file="${TEST_DIR}/${WORKFLOW_NAME}/vars.txt" "${WORKFLOW_NAME}"
 #-------------------------------------------------------------------------------
 purge

--- a/tests/functional/job-file-trap/00-sigusr1.t
+++ b/tests/functional/job-file-trap/00-sigusr1.t
@@ -29,7 +29,7 @@ run_tests() {
     run_ok "${TEST_NAME}" cylc validate "${WORKFLOW_NAME}"
     TEST_NAME="${TEST_NAME_BASE}-run"
     # Needs to be detaching:
-    workflow_run_ok "${TEST_NAME}" cylc play --debug --reference-test "${WORKFLOW_NAME}"
+    workflow_run_ok "${TEST_NAME}" cylc play --reference-test "${WORKFLOW_NAME}"
 
     # Make sure 1/t1's status file is in place
     T1_STATUS_FILE="${WORKFLOW_RUN_DIR}/log/job/1/t1/01/job.status"

--- a/tests/functional/job-file-trap/02-pipefail.t
+++ b/tests/functional/job-file-trap/02-pipefail.t
@@ -24,7 +24,7 @@ TEST_NAME="${TEST_NAME_BASE}-validate"
 run_ok "${TEST_NAME}-validate" cylc validate "${WORKFLOW_NAME}"
 TEST_NAME="${TEST_NAME_BASE}-run"
 workflow_run_fail "${TEST_NAME_BASE}-run" \
-    cylc play --no-detach --debug --reference-test "${WORKFLOW_NAME}"
+    cylc play --no-detach --reference-test "${WORKFLOW_NAME}"
 
 # Make sure status files are in place
 T1_STATUS_FILE="${WORKFLOW_RUN_DIR}/log/job/1/t1/01/job.status"

--- a/tests/functional/modes/02-dummy-message-outputs.t
+++ b/tests/functional/modes/02-dummy-message-outputs.t
@@ -23,6 +23,6 @@ set_test_number 2
 install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
 workflow_run_ok "${TEST_NAME_BASE}-run" \
-    cylc play --no-detach --mode=dummy --debug --reference-test "${WORKFLOW_NAME}"
+    cylc play --no-detach --mode=dummy --reference-test "${WORKFLOW_NAME}"
 purge
 exit

--- a/tests/functional/remote/03-polled-task-started.t
+++ b/tests/functional/remote/03-polled-task-started.t
@@ -25,7 +25,7 @@ install_workflow
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "$WORKFLOW_NAME"
 
-workflow_run_ok "${TEST_NAME_BASE}-run" cylc play --debug --reference-test --no-detach "$WORKFLOW_NAME"
+workflow_run_ok "${TEST_NAME_BASE}-run" cylc play --reference-test --no-detach "$WORKFLOW_NAME"
 
 # Check 'started' event handlers ran
 PICARD_ACTIVITY_LOG="${WORKFLOW_RUN_DIR}/log/job/1/picard/01/job-activity.log"

--- a/tests/functional/restart/28-execution-timeout.t
+++ b/tests/functional/restart/28-execution-timeout.t
@@ -23,7 +23,7 @@ install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
 workflow_run_ok "${TEST_NAME_BASE}-run" cylc play "${WORKFLOW_NAME}" --no-detach
 workflow_run_ok "${TEST_NAME_BASE}-restart" \
-    cylc play "${WORKFLOW_NAME}" --no-detach --debug --reference-test
+    cylc play "${WORKFLOW_NAME}" --no-detach --reference-test
 contains_ok "${WORKFLOW_RUN_DIR}/log/job/1/foo/NN/job-activity.log" <<'__LOG__'
 [(('event-handler-00', 'execution timeout'), 1) cmd] echo 1/foo 'execution timeout'
 [(('event-handler-00', 'execution timeout'), 1) ret_code] 0

--- a/tests/functional/spawn-on-demand/07-abs-triggers.t
+++ b/tests/functional/spawn-on-demand/07-abs-triggers.t
@@ -27,7 +27,7 @@ install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
 
 workflow_run_ok "${TEST_NAME_BASE}-run" \
-    cylc play "${WORKFLOW_NAME}" --debug --reference-test --no-detach --stopcp=3
+    cylc play "${WORKFLOW_NAME}"  --reference-test --no-detach --stopcp=3
 
 # Restart will hang if abs triggers not remembered.
 workflow_run_ok "${TEST_NAME_BASE}-restart" \


### PR DESCRIPTION
* Logging level for trigger items was reduced causing failures when test workflows were not run in debug mode.
* Bump the log level up when running in reftest (or genref) modes to avoid the issue.