### PR TITLE
restart: test prereq changes are applied on restart

### DIFF
--- a/tests/integration/utils/flow_tools.py
+++ b/tests/integration/utils/flow_tools.py
@@ -55,11 +55,15 @@ def _make_flow(
     test_dir: Path,
     conf: Union[dict, str],
     name: Optional[str] = None,
+    id_: Optional[str] = None,
 ) -> str:
     """Construct a workflow on the filesystem."""
-    if name is None:
-        name = str(uuid1())
-    flow_run_dir = (test_dir / name)
+    if id_:
+        flow_run_dir = (cylc_run_dir / id_)
+    else:
+        if name is None:
+            name = str(uuid1())
+        flow_run_dir = (test_dir / name)
     flow_run_dir.mkdir(parents=True, exist_ok=True)
     reg = str(flow_run_dir.relative_to(cylc_run_dir))
     if isinstance(conf, dict):


### PR DESCRIPTION
* Tests https://github.com/cylc/cylc-flow/pull/5334

This fails on upstream/8.1.x with the following traceback:

```
Traceback (most recent call last):    
  File "~/cylc-flow/cylc/flow/scheduler.py", line 687, in start
    await self.configure()
  File "~/cylc-flow/cylc/flow/scheduler.py", line 476, in configure                         
    self._load_pool_from_db()    
  File "~/cylc-flow/cylc/flow/scheduler.py", line 738, in _load_pool_from_db                         
    self.pool.load_db_task_pool_for_restart)    
  File "~/cylc-flow/cylc/flow/rundb.py", line 894, in select_task_pool_for_restart                         
    callback(row_idx, list(row))    
  File "~/cylc-flow/cylc/flow/task_pool.py", line 508, in load_db_task_pool_for_restart                                             
    itask_prereq.satisfied[key] = sat[key]    
KeyError: ('1', 'c', 'succeeded')  
```