### PR TITLE
pool: load missing prerequisite status from database

### DIFF
--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -21,8 +21,14 @@ from collections import Counter
 import json
 from time import time
 from typing import (
-    Dict, Iterable, List, Optional,
-    Set, TYPE_CHECKING, Tuple
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    TYPE_CHECKING,
+    Tuple,
+    Union,
 )
 import logging
 
@@ -421,6 +427,30 @@ class TaskPool:
         cycle, name, output = row
         self.abs_outputs_done.add((cycle, name, output))
 
+    def check_task_output(
+        self,
+        cycle: str,
+        task: str,
+        output: str,
+        flow_nums: 'FlowNums',
+    ) -> Union[str, bool]:
+        """Returns truthy if the specified output is satisfied in the DB."""
+        for task_outputs, task_flow_nums in (
+            self.workflow_db_mgr.pri_dao.select_task_outputs(task, cycle)
+        ).items():
+            # loop through matching tasks
+            if flow_nums.intersection(task_flow_nums):
+                # this task is in the right flow
+                task_outputs = json.loads(task_outputs)
+                return (
+                    'satisfied naturally'
+                    if output in task_outputs
+                    else False
+                )
+        else:
+            # no matching entries
+            return False
+
     def load_db_task_pool_for_restart(self, row_idx, row):
         """Load tasks from DB task pool/states/jobs tables.
 
@@ -512,7 +542,17 @@ class TaskPool:
                     except KeyError:
                         # This prereq is not in the DB: new dependencies
                         # added to an already-spawned task before restart.
-                        itask_prereq.satisfied[key] = False
+                        # Look through task outputs to see if is has been
+                        # satisfied
+                        prereq_cycle, prereq_task, prereq_output = key
+                        itask_prereq.satisfied[key] = (
+                            self.check_task_output(
+                                prereq_cycle,
+                                prereq_task,
+                                prereq_output,
+                                itask.flow_nums,
+                            )
+                        )
 
             if itask.state_reset(status, is_runahead=True):
                 self.data_store_mgr.delta_task_runahead(itask)
@@ -915,7 +955,10 @@ class TaskPool:
                 new_task = TaskProxy(
                     self.config.get_taskdef(itask.tdef.name),
                     itask.point, itask.flow_nums, itask.state.status)
-                itask.copy_to_reload_successor(new_task)
+                itask.copy_to_reload_successor(
+                    new_task,
+                    self.check_task_output,
+                )
                 self._swap_out(new_task)
                 LOG.info(f"[{itask}] reloaded task definition")
                 if itask.state(*TASK_STATUSES_ACTIVE):

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -17,7 +17,6 @@
 from cylc.flow import CYLC_LOG
 from copy import deepcopy
 import logging
-from pathlib import Path
 import pytest
 from pytest import param
 from typing import AsyncGenerator, Callable, Iterable, List, Tuple, Union
@@ -33,10 +32,6 @@ from cylc.flow.task_state import (
     TASK_STATUS_RUNNING,
     TASK_STATUS_SUCCEEDED,
 )
-
-from cylc.flow.pathutil import get_cylc_run_dir, get_workflow_run_dir
-from .utils.flow_tools import _make_flow
-
 
 # NOTE: foo and bar have no parents so at start-up (even with the workflow
 # paused) they get spawned out to the runahead limit. 2/pub spawns
@@ -808,8 +803,7 @@ async def test_reload_prereqs(
 
         # Modify flow.cylc to add a new dependency on "z"
         conf['scheduling']['graph']['R1'] = graph_2
-        run_dir = Path(get_workflow_run_dir(id_))
-        _make_flow(get_cylc_run_dir(), run_dir, conf, '')
+        flow(conf, id_=id_)
 
         # Reload the workflow config
         schd.command_reload_workflow()
@@ -825,3 +819,102 @@ async def test_reload_prereqs(
             ),
             key=lambda d: tuple(d.keys())[0],
         ) == expected_4
+
+
+async def _test_restart_prereqs_sat():
+    # YIELD: the workflow has now started...
+    schd = yield
+
+    # Release tasks 1/a and 1/b
+    schd.pool.release_runahead_tasks()
+    schd.release_queued_tasks()
+    assert list_tasks(schd) == [
+        ('1', 'a', 'running'),
+        ('1', 'b', 'running')
+    ]
+
+    # Mark both as succeeded and spawn 1/c
+    for itask in schd.pool.get_all_tasks():
+        itask.state_reset('succeeded')
+        schd.pool.spawn_on_output(itask, 'succeeded')
+        schd.workflow_db_mgr.put_insert_task_outputs(itask)
+        schd.pool.remove_if_complete(itask)
+    schd.workflow_db_mgr.process_queued_ops()
+    assert list_tasks(schd) == [
+        ('1', 'c', 'waiting')
+    ]
+
+    # YIELD: the workflow has now restarted or reloaded with the new config...
+    schd = yield
+    assert list_tasks(schd) == [
+        ('1', 'c', 'waiting')
+    ]
+
+    # Check resulting dependencies of task z
+    task_c = schd.pool.get_all_tasks()[0]
+    assert sorted(
+        (*key, satisfied)
+        for prereq in task_c.state.prerequisites
+        for key, satisfied in prereq.satisfied.items()
+    ) == [
+        ('1', 'a', 'succeeded', 'satisfied naturally'),
+        ('1', 'b', 'succeeded', 'satisfied naturally')
+    ]
+
+
+@pytest.mark.parametrize('do_restart', [True, False])
+async def test_graph_change_prereq_satisfaction(
+    flow, scheduler, start, do_restart
+):
+    """It should handle graph prerequisites change on reload/restart.
+
+    If the graph is changed to add a dependency which has been previously
+    satisfied, then Cylc should perform a DB check and mark the prerequsite
+    as satisfied accordingly.
+
+    See https://github.com/cylc/cylc-flow/pull/5334
+
+    """
+    conf = {
+        'scheduler': {'allow implicit tasks': 'True'},
+        'scheduling': {
+            'graph': {
+                'R1': '''
+                    a => c
+                    b
+                '''
+            }
+        }
+    }
+    id_ = flow(conf)
+    schd = scheduler(id_, run_mode='simulation', paused_start=False)
+
+    test = _test_restart_prereqs_sat()
+    test.asend(None)
+
+    if do_restart:
+        async with start(schd):
+            # start the workflow and run part 1 of the tests
+            test.asend(schd)
+
+        # shutdown and change the workflow definiton
+        conf['scheduling']['graph']['R1'] += '\nb => c'
+        flow(conf, id_=id_)
+        schd = scheduler(id_, run_mode='simulation', paused_start=False)
+
+        async with start(schd):
+            # restart the workflow and run part 2 of the tests
+            test.asend(schd)
+
+    else:
+        async with start(schd):
+            test.asend(schd)
+
+            # Modify flow.cylc to add a new dependency on "b"
+            conf['scheduling']['graph']['R1'] += '\nb => c'
+            flow(conf, id_=id_)
+
+            # Reload the workflow config
+            schd.command_reload_workflow()
+
+            test.asend(schd)


### PR DESCRIPTION
> **Built On:** #5328

If a prerequisite is missing from the database on reload/restart, then look through the task outputs table to see whether it is satisfied.

Two issues/questions:

1. I'm not sure how to square this with the data store without duplicating the database calls.
2. This PR marks all satisfied prerequisites as `satisfied naturally`. I think the information is lost by this point, is there a more suitable value e.g `satisfied from DB`?
