### PR TITLE
Tests: fix cached point parse contamination between tests

### DIFF
--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -20,11 +20,17 @@ jobs:
       fail-fast: false # Don't let a failed MacOS run stop the Ubuntu runs
       matrix:
         os: ['ubuntu-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.10', '3.11']
         include:
+          # mac os test
           - os: 'macos-latest'
-            python-version: '3.7'
+            python-version: '3.7'  # oldest supported version
+          # non-utc timezone test
+          - os: 'ubuntu-latest'
+            python-version: '3.9'  # not the oldest, not the most recent version
+            time-zone: 'XXX-09:35'
     env:
+      TZ: ${{ matrix.time-zone }}
       PYTEST_ADDOPTS: --cov --cov-append -n 5 --color=yes
     steps:
       - name: Checkout

--- a/cylc/flow/cycling/iso8601.py
+++ b/cylc/flow/cycling/iso8601.py
@@ -943,12 +943,22 @@ def _interval_parse(interval_string):
 
 def point_parse(point_string: str) -> 'TimePoint':
     """Parse a point_string into a proper TimePoint object."""
-    return _point_parse(point_string, WorkflowSpecifics.DUMP_FORMAT)
+    return _point_parse(
+        point_string,
+        WorkflowSpecifics.DUMP_FORMAT,
+        WorkflowSpecifics.ASSUMED_TIME_ZONE
+    )
 
 
 @lru_cache(10000)
-def _point_parse(point_string, _dump_fmt):
-    """Parse a point_string into a proper TimePoint object."""
+def _point_parse(point_string: str, _dump_fmt, _tz) -> 'TimePoint':
+    """Parse a point_string into a proper TimePoint object.
+
+    Args:
+        point_string: The string to parse.
+        _dump_fmt: Dump format (only used to avoid invalid cache hits).
+        _tz: Cycle point time zone (only used to avoid invalid cache hits).
+    """
     if "%" in WorkflowSpecifics.DUMP_FORMAT:
         # May be a custom not-quite ISO 8601 dump format.
         with contextlib.suppress(IsodatetimeError):

--- a/pytest.ini
+++ b/pytest.ini
@@ -32,9 +32,6 @@ testpaths =
     cylc/flow/
     tests/unit/
     tests/integration/
-env =
-    # a weird timezone to check that tests aren't assuming the local timezone
-    # TZ=XXX-09:35
 doctest_optionflags =
     NORMALIZE_WHITESPACE
     IGNORE_EXCEPTION_DETAIL

--- a/setup.cfg
+++ b/setup.cfg
@@ -119,7 +119,6 @@ tests =
     pytest-asyncio>=0.17,!=0.23.*
     pytest-cov>=2.8.0
     pytest-xdist>=2
-    pytest-env>=0.6.2
     pytest>=6
     testfixtures>=6.11.0
     towncrier>=23

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -1291,7 +1291,6 @@ async def test_compute_runahead(
             'scheduler': {
                 'allow implicit tasks': 'True',
                 'cycle point format': 'CCYY',
-                'cycle point time zone': 'Z'
             },
             'scheduling': {
                 'initial cycle point': '0001',


### PR DESCRIPTION
In back-compat mode the cycle point time zone is assumed to be local, whereas in normal mode it is assumed to be UTC. There was contamination of the point parse caching where the time zone would carry over from tests of back-compat vs normal mode.

Also removed pytest-env because it doesn't work with pytest-xdist (copied from master - see https://github.com/cylc/cylc-flow/pull/5826/commits/be46a11115294ab41f00b3a6a76ffacb29b28d32)