### PR TITLE
tokens: avoid surplus detokenising

### DIFF
--- a/cylc/flow/prerequisite.py
+++ b/cylc/flow/prerequisite.py
@@ -202,7 +202,7 @@ class Prerequisite:
                 '"%s":\n%s' % (self.get_raw_conditional_expression(), err_msg))
         return res
 
-    def satisfy_me(self, outputs: Iterable['Tokens']) -> Set[str]:
+    def satisfy_me(self, outputs: Iterable['Tokens']) -> 'Set[Tokens]':
         """Attempt to satisfy me with given outputs.
 
         Updates cache with the result.
@@ -214,7 +214,7 @@ class Prerequisite:
             prereq = output.to_prereq_tuple()
             if prereq not in self.satisfied:
                 continue
-            valid.add(output.relative_id_with_selectors)
+            valid.add(output)
             self.satisfied[prereq] = self.DEP_STATE_SATISFIED
             if self.conditional_expression is None:
                 self._all_satisfied = all(self.satisfied.values())

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -37,7 +37,6 @@ from metomi.isodatetime.timezone import get_local_time_zone
 
 from cylc.flow import LOG
 from cylc.flow.flow_mgr import stringify_flow_nums
-from cylc.flow.id import Tokens
 from cylc.flow.platforms import get_platform
 from cylc.flow.task_action_timer import TimerFlags
 from cylc.flow.task_state import (
@@ -57,6 +56,7 @@ if TYPE_CHECKING:
     from cylc.flow.cycling import PointBase
     from cylc.flow.task_action_timer import TaskActionTimer
     from cylc.flow.taskdef import TaskDef
+    from cylc.flow.id import Tokens
 
 
 class TaskProxy:
@@ -518,18 +518,17 @@ class TaskProxy:
             return True
         return False
 
-    def satisfy_me(self, outputs: Iterable[str]) -> None:
+    def satisfy_me(self, outputs: 'Iterable[Tokens]') -> None:
         """Try to satisfy my prerequisites with given outputs.
 
         The output strings are of the form "cycle/task:message"
         Log a warning for outputs that I don't depend on.
 
         """
-        tokens = [Tokens(p, relative=True) for p in outputs]
-        used = self.state.satisfy_me(tokens)
+        used = self.state.satisfy_me(outputs)
         for output in set(outputs) - used:
             LOG.warning(
-                f"{self.identity} does not depend on {output}"
+                f"{self.identity} does not depend on {output.relative_id_with_selectors}"
             )
 
     def clock_expire(self) -> bool:

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -528,7 +528,8 @@ class TaskProxy:
         used = self.state.satisfy_me(outputs)
         for output in set(outputs) - used:
             LOG.warning(
-                f"{self.identity} does not depend on {output.relative_id_with_selectors}"
+                f"{self.identity} does not depend on"
+                f" {output.relative_id_with_selectors}"
             )
 
     def clock_expire(self) -> bool:

--- a/cylc/flow/task_state.py
+++ b/cylc/flow/task_state.py
@@ -313,12 +313,12 @@ class TaskState:
     def satisfy_me(
         self,
         outputs: Iterable['Tokens']
-    ) -> Set[str]:
+    ) -> Set['Tokens']:
         """Try to satisfy my prerequisites with given outputs.
 
         Return which outputs I actually depend on.
         """
-        valid: Set[str] = set()
+        valid: Set[Tokens] = set()
         for prereq in (*self.prerequisites, *self.suicide_prerequisites):
             yep = prereq.satisfy_me(outputs)
             if yep:

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -32,8 +32,9 @@ from json import loads
 from cylc.flow import CYLC_LOG
 from cylc.flow.cycling.integer import IntegerPoint
 from cylc.flow.cycling.iso8601 import ISO8601Point
-from cylc.flow.task_events_mgr import TaskEventsManager
 from cylc.flow.data_store_mgr import TASK_PROXIES
+from cylc.flow.id import Tokens
+from cylc.flow.task_events_mgr import TaskEventsManager
 from cylc.flow.task_outputs import (
     TASK_OUTPUT_STARTED,
     TASK_OUTPUT_SUCCEEDED
@@ -1523,7 +1524,10 @@ async def test_prereq_satisfaction(
         assert not b.is_waiting_prereqs_done()
 
         # set valid and invalid prerequisites, check log.
-        b.satisfy_me(["1/a:x", "1/a:y", "1/a:z", "1/a:w"])
+        b.satisfy_me([
+            Tokens(id_, relative=True)
+            for id_ in ["1/a:x", "1/a:y", "1/a:z", "1/a:w"]
+        ])
         assert log_filter(log, contains="1/b does not depend on 1/a:z")
         assert log_filter(log, contains="1/b does not depend on 1/a:w")
         assert not log_filter(log, contains="1/b does not depend on 1/a:x")


### PR DESCRIPTION
Pass tokens objects a bit deeper into the code to avoid unnecessary detokenisation / string formatting.