### PR TITLE
cylc set stuffs

### DIFF
--- a/cylc/flow/unicode_rules.py
+++ b/cylc/flow/unicode_rules.py
@@ -23,6 +23,7 @@ from cylc.flow.task_id import (
     _TASK_NAME_PREFIX,
 )
 from cylc.flow.task_qualifiers import TASK_QUALIFIERS
+from cylc.flow.task_state import TASK_STATUSES_ORDERED
 
 ENGLISH_REGEX_MAP = {
     r'\w': 'alphanumeric',
@@ -350,8 +351,8 @@ class TaskOutputValidator(UnicodeRuleChecker):
         not_starts_with('_cylc'),
         # blacklist keywords
         not_equals('required', 'optional', 'all'),
-        # blacklist built-in task qualifiers
-        not_equals(*TASK_QUALIFIERS),
+        # blacklist built-in task qualifiers and statuses (e.g. "waiting")
+        not_equals(*sorted({*TASK_QUALIFIERS, *TASK_STATUSES_ORDERED})),
     ]
 
 

--- a/tests/functional/authentication/00-shared-fs.t
+++ b/tests/functional/authentication/00-shared-fs.t
@@ -41,8 +41,8 @@ WORKFLOW_LOG="${WORKFLOW_RUN_DIR}/log/scheduler/log"
 # Note: double poll existence of workflow log on workflow host and then localhost to
 # avoid any issues with unstable mounting of the shared file system.
 poll ssh -oBatchMode=yes -n "${CYLC_TEST_HOST}" test -e "${WORKFLOW_LOG}"
-poll_grep_workflow_log -E '19700101T0000Z/t1 submitted .* => running'
-poll_grep_workflow_log -E '19700101T0000Z/t1 running .* => failed'
+poll_grep_workflow_log -E '19700101T0000Z/t1/01:submitted.* => running'
+poll_grep_workflow_log -E '19700101T0000Z/t1/01:running.* => failed'
 
 run_ok "${TEST_NAME_BASE}-broadcast" \
     cylc broadcast -n 't1' -s '[environment]CYLC_TEST_VAR_FOO=foo' "${WORKFLOW_NAME}"


### PR DESCRIPTION
This fixes a test which was broken by log format changes but isn't run in CI.

It also adds some extra validation to the `cylc set` command to catch some likely user errors.