### PR TITLE
Prevent malformed `--pre` options taking the scheduler down

### DIFF
--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1704,12 +1704,7 @@ class TaskPool:
                 # The CP from --pre is invalid:
                 LOG.warning(f'Invalid pre cycle point set:\n    {exc.args[0]}')
             else:
-            _prereqs[
-                pre.duplicate(
-                    task_sel=msg,
-                    cycle=standardise_point_string(pre['cycle'])
-                )
-            ] = prereq
+                _prereqs[pre.duplicate(task_sel=msg, cycle=cycle)] = prereq
         return _prereqs
 
     def _standardise_outputs(

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1715,7 +1715,7 @@ class TaskPool:
                 msg = self.config.get_taskdef(
                     pre['task']
                 ).outputs[output][0]
-                cycle=standardise_point_string(pre['cycle'])
+                cycle = standardise_point_string(pre['cycle'])
             except KeyError:
                 # The task does not have this output.
                 LOG.warning(

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1715,17 +1715,25 @@ class TaskPool:
                 msg = self.config.get_taskdef(
                     pre['task']
                 ).outputs[output][0]
+                cycle=standardise_point_string(pre['cycle'])
             except KeyError:
                 # The task does not have this output.
                 LOG.warning(
                     f"output {pre.relative_id_with_selectors} not found")
                 continue
-            _prereqs.append(
-                pre.duplicate(
-                    task_sel=msg,
-                    cycle=standardise_point_string(pre['cycle'])
+            except WorkflowConfigError as exc:
+                # The workflow does not have the task from --pre:
+                LOG.warning(f'Invalid pre task name set:\n    {exc.args[0]}')
+            except PointParsingError as exc:
+                # The CP from --pre is invalid:
+                LOG.warning(f'Invalid pre cycle point set:\n    {exc.args[0]}')
+            else:
+                _prereqs.append(
+                    pre.duplicate(
+                        task_sel=msg,
+                        cycle=cycle,
+                    )
                 )
-            )
         return _prereqs
 
     def _standardise_outputs(

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1698,11 +1698,11 @@ class TaskPool:
                     f"output {pre.relative_id_with_selectors} not found")
                 continue
             except WorkflowConfigError as exc:
-                # The workflow does not have the task from --pre:
-                LOG.warning(f'Invalid pre task name set:\n    {exc.args[0]}')
+                LOG.warning(
+                    f'Invalid prerequisite task name:\n{exc.args[0]}')
             except PointParsingError as exc:
-                # The CP from --pre is invalid:
-                LOG.warning(f'Invalid pre cycle point set:\n    {exc.args[0]}')
+                LOG.warning(
+                    f'Invalid prerequisite cycle point:\n{exc.args[0]}')
             else:
                 _prereqs[pre.duplicate(task_sel=msg, cycle=cycle)] = prereq
         return _prereqs

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -33,10 +33,8 @@ from cylc.flow import CYLC_LOG
 from cylc.flow.cycling.integer import IntegerPoint
 from cylc.flow.cycling.iso8601 import ISO8601Point
 from cylc.flow.data_store_mgr import TASK_PROXIES
-from cylc.flow.id import Tokens
 from cylc.flow.task_events_mgr import TaskEventsManager
 from cylc.flow.task_outputs import (
-    TASK_OUTPUT_STARTED,
     TASK_OUTPUT_SUCCEEDED
 )
 
@@ -50,7 +48,6 @@ from cylc.flow.task_state import (
     TASK_STATUS_FAILED,
     TASK_STATUS_EXPIRED,
     TASK_STATUS_SUBMIT_FAILED,
-    TASK_STATUSES_ALL,
 )
 
 if TYPE_CHECKING:
@@ -1345,28 +1342,43 @@ async def test_set_prereqs(
 
         # it should start up with foo, bar, baz
         assert (
-            pool_get_task_ids(schd.pool) == ["20400101T0000Z/bar", "20400101T0000Z/baz", "20400101T0000Z/foo"]
+            pool_get_task_ids(schd.pool) == [
+                "20400101T0000Z/bar",
+                "20400101T0000Z/baz",
+                "20400101T0000Z/foo"]
         )
 
         # try to set an invalid prereq of qux
         schd.pool.set_prereqs_and_outputs(
             ["20400101T0000Z/qux"], None, ["20400101T0000Z/foo:a"], ['all'])
         assert log_filter(
-            log, contains='20400101T0000Z/qux does not depend on "20400101T0000Z/foo:drugs and money"')
+            log, contains=(
+                '20400101T0000Z/qux does not depend on '
+                '"20400101T0000Z/foo:drugs and money"'
+            ))
 
         # it should not add 20400101T0000Z/qux to the pool
         assert (
-            pool_get_task_ids(schd.pool) == ["20400101T0000Z/bar", "20400101T0000Z/baz", "20400101T0000Z/foo"]
+            pool_get_task_ids(schd.pool) == [
+                "20400101T0000Z/bar",
+                "20400101T0000Z/baz",
+                "20400101T0000Z/foo"]
         )
 
         # set one prereq of future task 20400101T0000Z/qux
         schd.pool.set_prereqs_and_outputs(
-            ["20400101T0000Z/qux"], None, ["20400101T0000Z/foo:succeeded"], ['all'])
+            ["20400101T0000Z/qux"],
+            None,
+            ["20400101T0000Z/foo:succeeded"],
+            ['all'])
 
         # it should add 20400101T0000Z/qux to the pool
         assert (
             pool_get_task_ids(schd.pool) == [
-                "20400101T0000Z/bar", "20400101T0000Z/baz", "20400101T0000Z/foo", "20400101T0000Z/qux"
+                "20400101T0000Z/bar",
+                "20400101T0000Z/baz",
+                "20400101T0000Z/foo",
+                "20400101T0000Z/qux"
             ]
         )
 

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -1417,13 +1417,13 @@ async def test_set_bad_prereqs(
             ["2040/bar"], None, prereqs, ['all'])
 
     async with start(schd) as log:
-        # Invalid - task name wildcard:
+        # Invalid: task name wildcard:
         set_prereqs(["2040/*"])
-        assert 'Illegal task name' in log.messages[-1]
+        assert log_filter(log, contains='Invalid prerequisite task name' )
 
-        # Invalid cycle point wildcard.
+        # Invalid: cycle point wildcard.
         set_prereqs(["*/foo"])
-        assert 'Invalid ISO 8601' in log.messages[-1]
+        assert log_filter(log, contains='Invalid prerequisite cycle point')
 
 
 async def test_set_outputs_live(


### PR DESCRIPTION
### Replicate Bug

(copied from https://github.com/cylc/cylc-flow/pull/5658#issuecomment-1980840903) so you don't have to follow the link.

Running a noddy workflow
 
```
cylc set cylc-set/basic//1/bar --pre='1/*:succeeded'
```

Gets sent successfully to the scheduler but then casuses the scheduler to fail

```
...
      File "/media/tim/Data1/tims_code/metomi/cylc-flow/cylc/flow/config.py", line 2215, in get_taskdef
        raise WorkflowConfigError(str(exc))
    cylc.flow.exceptions.WorkflowConfigError: Illegal task name: *
```

However daft a user's choice of input to set is, I don't think it ought ever crash the scheduler: And I don't think that this is super daft thing to ask for.