### PR TITLE
Make set trigger outputs in order

### DIFF
--- a/cylc/flow/task_outputs.py
+++ b/cylc/flow/task_outputs.py
@@ -310,9 +310,7 @@ class TaskOutputs:
             >>> sorted(['finished', 'started',  'custom'], key=this)
             ['started', 'custom', 'finished']
         """
-        task_outputs = {o: i for i, o in enumerate(TASK_OUTPUTS)}
         if item in TASK_OUTPUTS:
-            return task_outputs[item]
-        else:
-            # Sorts custom outputs after started.
-            return TASK_OUTPUTS.index(TASK_OUTPUT_STARTED) + .5
+            return TASK_OUTPUTS.index(item)
+        # Sort custom outputs after started.
+        return TASK_OUTPUTS.index(TASK_OUTPUT_STARTED) + .5

--- a/cylc/flow/task_outputs.py
+++ b/cylc/flow/task_outputs.py
@@ -299,3 +299,20 @@ class TaskOutputs:
         except ValueError:
             ind = 999
         return (ind, item[_MESSAGE] or '')
+
+    @staticmethod
+    def output_sort_key(item):
+        """Compare by output order.
+
+        Examples:
+
+            >>> this = TaskOutputs.output_sort_key
+            >>> sorted(['finished', 'started',  'custom'], key=this)
+            ['started', 'custom', 'finished']
+        """
+        task_outputs = {o: i for i, o in enumerate(TASK_OUTPUTS)}
+        if item in TASK_OUTPUTS:
+            return task_outputs[item]
+        else:
+            # Sorts custom outputs after started.
+            return TASK_OUTPUTS.index(TASK_OUTPUT_STARTED) + .5

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1820,6 +1820,7 @@ class TaskPool:
                 itask.point, itask.tdef, outputs)
 
         changed = False
+        outputs = sorted(outputs, key=itask.state.outputs.output_sort_key)
         for output in outputs:
             if itask.state.outputs.is_completed(output):
                 LOG.info(f"output {itask.identity}:{output} completed already")


### PR DESCRIPTION
### What has changed in this branch.

Cylc set sorts outputs before emitting them.

### What problem does this solve

if you run a simple workflow:

```ini
[scheduling]
    cycling mode = integer
    [[graph]]
        R1 = """
            foo:a & foo:b => bar
        """

[runtime]
    [[foo]]
        script = sleep 300
        [[[outputs]]]
            a = 'apple (poisoned)'
            b = 'banshee'
    [[bar]]
```

set it running then 

```console
cylc set set/basic//1/foo    # --out=required
```

gets the following message:

```
2024-03-11T13:48:42Z INFO - [1/foo/01:submitted] setting implied output: started
2024-03-11T13:48:42Z INFO - [1/foo/01:submitted] => succeeded
2024-03-11T13:48:42Z WARNING - [1/foo/01:succeeded] did not complete required outputs: ['a', 'b']
2024-03-11T13:48:42Z INFO - [1/foo/01:succeeded] completed output a
2024-03-11T13:48:42Z INFO - [1/bar:waiting(runahead)] added to active task pool
2024-03-11T13:48:42Z INFO - [1/bar:waiting(runahead)] => waiting
2024-03-11T13:48:42Z INFO - [1/foo/01:succeeded] completed output b

```

Confusing IMO.

