### PR TITLE
dict(was hiding stuff)

### DIFF
--- a/cylc/flow/graph_parser.py
+++ b/cylc/flow/graph_parser.py
@@ -470,8 +470,7 @@ class GraphParser:
                 pairs.add((chain[i], chain[i + 1]))
 
         # Get a set of RH nodes which are not at the LH of another pair:
-        pairs_dict = dict(pairs)
-        terminals = set(pairs_dict.values()).difference(pairs_dict.keys())
+        terminals = {p[1] for p in pairs}.difference({p[0] for p in pairs})
 
         for pair in pairs:
             self._proc_dep_pair(pair, terminals)


### PR DESCRIPTION
Conversion of pairs tuple to dict was throwing away information.

```python
pairs = ((None, 1), (None, 2))
# This isn't deterministic!
print(dict(pairs))
>>> {None: 1}
print(dict(pairs))
>>> {None: 2}
```