### PR TITLE
trigger: restore n=0 flow behaviour for unconnected graphs

### DIFF
--- a/cylc/flow/util.py
+++ b/cylc/flow/util.py
@@ -28,10 +28,13 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Generator,
     List,
     Optional,
     Sequence,
+    Set,
     Tuple,
+    TypeVar,
 )
 
 
@@ -457,3 +460,56 @@ def get_variable_names(expression):
     walker = NameWalker()
     walker.visit(ast.parse(expression))
     return walker.names
+
+
+Key = TypeVar('Key')
+
+
+def get_connected_groups(
+    graph: Dict[Key, Set[Key]],
+) -> Generator[Set[Key], None, None]:
+    """Extract connected components in an undirected graph.
+
+    Args:
+        graph:
+            The graph in the form of an adjacency dictionary where each node
+            is listed against its adjacent nodes. Note, this method is for
+            undirected graphs, so this includes both upstream & downstream
+            nodes if you are using this with a directed graph.
+            e.g, {node: {adjacent_node1, adjacent_node2}, ...}
+
+    Yields:
+        Each connected group within the graph.
+
+    Example:
+        # a - b - c - d
+        # b - d
+        # e - f
+        >>> adjacency = {
+        ...     'a': {'b'},
+        ...     'b': {'a', 'c', 'd'},
+        ...     'c': {'b', 'd'},
+        ...     'd': {'c', 'b'},
+        ...     'e': {'f'},
+        ...     'f': {'e'},
+        ... }
+
+        >>> sorted(sorted(group) for group in get_connected_groups(adjacency))
+        [['a', 'b', 'c', 'd'], ['e', 'f']]
+
+    """
+    # track the nodes we have already visited
+    visited: Dict[Key, bool] = dict.fromkeys(graph, False)
+
+    def visit(key: Key, group: Set[Key]) -> Set[Key]:
+        """Visit a node in the graph (recursive)."""
+        visited[key] = True
+        group.add(key)
+        for neighbour in graph[key]:
+            if not visited[neighbour]:
+                visit(neighbour, group)
+        return group
+
+    for key in visited:
+        if not visited[key]:
+            yield visit(key, set())

--- a/tests/integration/test_flow_assignment.py
+++ b/tests/integration/test_flow_assignment.py
@@ -129,12 +129,14 @@ async def test_flow_assignment(
 
         # -----(1. Test active tasks)-----
 
-        # By default active tasks merge existing and active flows.
         if command == "set":
+            # By default active tasks merge existing and active flows.
             do_command([active_1.identity], flow=[])
+            assert active_1.flow_nums == {1, 2}
         else:
+            # By default active tasks keep existing flows.
             await run_cmd(do_command([active_1.identity], flow=[]))
-        assert active_1.flow_nums == {1, 2}
+            assert active_1.flow_nums == {1}
 
         # Else merge existing and requested flows.
         if command == "set":

--- a/tests/integration/test_force_trigger.py
+++ b/tests/integration/test_force_trigger.py
@@ -501,3 +501,119 @@ async def test_trigger_group_in_flow(
             ('b', '[2]'),
             ('c', '[2]'),
         }
+
+
+async def test_trigger_n0_tasks(
+    flow,
+    scheduler,
+    run,
+    complete,
+    db_select,
+):
+    """It should trigger tasks within their flow if available, else all flows.
+
+    * N=0 tasks already have a flow assigned.
+    * N!=0 tasks do not yet have a flow assigned.
+
+    When we are triggering n!=0 tasks, there is no appropriate flow to run them
+    in (this would involve flow merge prediction), so we default to all active
+    flows as the most/only sensible default.
+
+    Before group trigger, we triggered tasks independently, i.e. we assumed
+    there were no dependencies between the tasks and ran them all
+    simultaneously. With the group trigger extension, we enhanced trigger to
+    make it aware of interdependent tasks.
+
+    Triggering independent tasks (pre group-trigger behaviour):
+      * If we trigger a n=0 task, we leave it in the flow it is already in.
+      * If we trigger a n!=0 task, we default to all active flows.
+
+    Triggering interdependent tasks (group trigger extension):
+      If the list of tasks being triggered contains any interdependent tasks,
+      we treat these interdependent tasks as a group.
+
+      * If we trigger a group which contains n=0 tasks, the whole group should
+        be triggered using the set of flows possessed by these n=0 tasks.
+      * If we trigger a group which does not contain n=0 tasks, we default to
+        all active flows.
+    """
+    id_ = flow({
+        'scheduling': {
+            'graph': {
+                'R1': '''
+                    # group 1 (we will trigger a, b & c)
+                    a => b => c => z
+
+                    # group 2 (we will trigger e, f & g)
+                    e => f => g => z
+
+                    # group 3 (we will trigger y)
+                    x => y => z
+                '''
+            }
+        }
+    })
+    schd = scheduler(id_, paused_start=False)
+    async with run(schd):
+        # cylc hold 1/x
+        await run_cmd(hold(schd, ['1/x']))
+
+        # group 1: spawn n>0 tasks into flows 2 & 3
+        await run_cmd(
+            set_prereqs_and_outputs(schd, ['1/b'], ['2'], None, ['all'])
+        )
+        await run_cmd(
+            set_prereqs_and_outputs(schd, ['1/c'], ['3'], None, ['all'])
+        )
+
+        # group 1: spawn n>0 tasks into flows 4 & 5
+        await run_cmd(
+            set_prereqs_and_outputs(schd, ['1/f'], ['4'], None, ['all'])
+        )
+        await run_cmd(
+            set_prereqs_and_outputs(schd, ['1/g'], ['5'], None, ['all'])
+        )
+
+        # trigger all three groups of tasks
+        await run_cmd(
+            force_trigger_tasks(
+                schd, ['1/a', '1/b', '1/c', '1/e', '1/f', '1/g', '1/y'], []
+            )
+        )
+
+        await complete(
+            schd, '1/a', '1/b', '1/c', '1/e', '1/f', '1/g', '1/y', '1/z'
+        )
+
+        assert set(db_select(
+            schd,
+            True,
+            'task_outputs',
+            'name',
+            'flow_nums',
+        )) == {
+            # junk entries inserted on spawn/set
+            ('a', '[1]'),  # initial flow spawned on startup
+            ('b', '[]'),   # created by "cylc set"
+            ('c', '[]'),   # created by "cylc set"
+            ('e', '[1]'),  # initial flow spawned on startup
+            ('f', '[]'),   # created by "cylc set"
+            ('g', '[]'),   # created by "cylc set"
+            ('x', '[1]'),  # initial flow spawned on startup
+
+            # group 1: contained tasks in flows 1, 2 & 3
+            ('a', '[1, 2, 3]'),
+            ('b', '[1, 2, 3]'),
+            ('c', '[1, 2, 3]'),
+
+            # group 2: contained tasks in flows 1, 4 & 5
+            ('e', '[1, 4, 5]'),
+            ('f', '[1, 4, 5]'),
+            ('g', '[1, 4, 5]'),
+
+            # group 3: contained tasks in flows None
+            ('y', '[1, 2, 3, 4, 5]'),
+
+            # x
+            ('z', '[1, 2, 3, 4, 5]'),
+        }

--- a/tests/integration/test_force_trigger.py
+++ b/tests/integration/test_force_trigger.py
@@ -566,7 +566,7 @@ async def test_trigger_n0_tasks(
             set_prereqs_and_outputs(schd, ['1/c'], ['3'], None, ['all'])
         )
 
-        # group 1: spawn n>0 tasks into flows 4 & 5
+        # group 2: spawn n>0 tasks into flows 4 & 5
         await run_cmd(
             set_prereqs_and_outputs(schd, ['1/f'], ['4'], None, ['all'])
         )
@@ -614,6 +614,6 @@ async def test_trigger_n0_tasks(
             # group 3: contained tasks in flows None
             ('y', '[1, 2, 3, 4, 5]'),
 
-            # x
+            # downstream task
             ('z', '[1, 2, 3, 4, 5]'),
         }


### PR DESCRIPTION
Revert the `--flow` behaviour changes on the group-trigger branch and replace it with something which maintains the previous behaviour for unconnected groups, but 

You might want to review this with `?w=1` on the end of the URL (hide whitespace changes in the force-trigger implementation)

#### New Behaviour

It should trigger tasks within their flow if available, else all flows.

* N=0 tasks already have a flow assigned.
* N!=0 tasks do not yet have a flow assigned.

When we are triggering n!=0 tasks, there is no appropriate flow to run them
in (this would involve flow merge prediction), so we default to all active
flows as the least objection ate default.

Before group trigger, we triggered tasks independently, i.e. we assumed
there were no dependencies between the tasks and ran them all
simultaneously. With the group trigger extension, we enhanced trigger to
make it aware of interdependent tasks.

Triggering independent tasks (pre group-trigger behaviour):
  * If we trigger a n=0 task, we leave it in the flow it is already in.
  * If we trigger a n!=0 task, we default to all active flows.

Triggering interdependent tasks (group trigger extension):
  If the list of tasks being triggered contains any interdependent tasks,
  we treat these interdependent tasks as a group.

  * If we trigger a group which contains n=0 tasks, the whole group should
    be triggered using the set of flows possessed by these n=0 tasks.
  * If we trigger a group which does not contain n=0 tasks, we default to
    all active flows.
